### PR TITLE
feat(ec2): opt-in launch options for instance containers (EC2_DOCKER_FLAGS)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- **EC2 — opt-in launch options for instance containers (`EC2_DOCKER_FLAGS`)** — a registered image that boots an operating system (systemd as PID 1) needs container options the fixed launch arguments cannot express: unprivileged, `unshare` fails with `Operation not permitted` and the instance terminates at boot. `EC2_DOCKER_FLAGS` now takes a docker-CLI-style string (`--privileged`, `--cap-add`, `-e`, `-v`, `--tmpfs`, `--add-host`, `-m`, `--shm-size`) applied to every instance container; unset, nothing changes. `--init` is refused — instance containers always run with init. Contributed by @iot-rocket.
+
 ## [1.5.0] — 2026-08-23
 
 ### Added

--- a/ministack/services/ec2.py
+++ b/ministack/services/ec2.py
@@ -87,6 +87,9 @@ logger = logging.getLogger("ec2")
 
 REGION = os.environ.get("MINISTACK_REGION", "us-east-1")
 DOCKER_NETWORK = os.environ.get("DOCKER_NETWORK", "")
+# docker-CLI-style flags applied to every instance container (e.g. --privileged
+# for a systemd guest). Parsed by _parse_ec2_docker_flags; --init is refused.
+EC2_DOCKER_FLAGS = os.environ.get("EC2_DOCKER_FLAGS", "")
 
 # Docker client, created on first use. Only registered images reach for it, so
 # an emulator nobody registered an AMI with never imports docker-py at all.
@@ -2111,6 +2114,75 @@ def _image_has_entrypoint(client, ref):
     return bool((image.attrs.get("Config") or {}).get("Entrypoint"))
 
 
+def _parse_ec2_docker_flags(flags: str) -> dict:
+    """Translate a docker-CLI-style ``EC2_DOCKER_FLAGS`` string into docker-py
+    ``containers.run()`` kwargs (subset; unknown flags are ignored, malformed
+    input is warned about and ignored rather than failing the launch).
+    ``--init`` is refused: init reaps whatever PID 1 leaves behind, and an image
+    with no ENTRYPOINT relies on it to reap the appended keepalive command —
+    disabling it silently breaks the box. Same approach as
+    ``_parse_docker_flags`` (``LAMBDA_DOCKER_FLAGS``) in ``lambda_svc.py``,
+    kept service-local like everything else in this file."""
+    if not flags:
+        return {}
+    import argparse
+    import shlex
+
+    try:
+        tokens = shlex.split(flags)
+    except ValueError as e:
+        logger.warning("EC2: could not parse EC2_DOCKER_FLAGS %r: %s", flags, e)
+        return {}
+    kept = []
+    for tok in tokens:
+        if tok == "--init" or tok.startswith("--init="):
+            logger.warning("EC2: ignoring %s in EC2_DOCKER_FLAGS — "
+                           "instance containers always run with init", tok)
+            continue
+        kept.append(tok)
+
+    class _QuietParser(argparse.ArgumentParser):
+        # argparse's default error() prints usage and calls sys.exit(), which
+        # must never happen inside the server — raise instead and warn below.
+        def error(self, message):
+            raise ValueError(message)
+
+    parser = _QuietParser(add_help=False)
+    parser.add_argument("-e", "--env", action="append", default=[])
+    parser.add_argument("-v", "--volume", action="append", default=[])
+    parser.add_argument("--cap-add", action="append", default=[])
+    parser.add_argument("--tmpfs", action="append", default=[])
+    parser.add_argument("--add-host", action="append", default=[])
+    parser.add_argument("-m", "--memory")
+    parser.add_argument("--shm-size")
+    parser.add_argument("--privileged", action="store_true")
+    try:
+        args, unknown = parser.parse_known_args(kept)
+    except ValueError as e:
+        logger.warning("EC2: could not parse EC2_DOCKER_FLAGS %r: %s", flags, e)
+        return {}
+    if unknown:
+        logger.debug("EC2: ignoring unsupported EC2_DOCKER_FLAGS tokens: %s", unknown)
+    kwargs = {}
+    if args.privileged:
+        kwargs["privileged"] = True
+    if args.env:
+        kwargs["environment"] = dict(e.partition("=")[::2] for e in args.env)
+    if args.volume:
+        kwargs["volumes"] = args.volume
+    if args.cap_add:
+        kwargs["cap_add"] = args.cap_add
+    if args.tmpfs:
+        kwargs["tmpfs"] = {path: opts for path, _, opts in (t.partition(":") for t in args.tmpfs)}
+    if args.add_host:
+        kwargs["extra_hosts"] = {h: ip for h, _, ip in (a.partition(":") for a in args.add_host)}
+    if args.memory:
+        kwargs["mem_limit"] = args.memory
+    if args.shm_size:
+        kwargs["shm_size"] = args.shm_size
+    return kwargs
+
+
 def _vm_launch(inst, image_ref):
     """Boot one instance record as a container. Raises on create/start failure;
     the caller backs the records out and surfaces the error."""
@@ -2144,6 +2216,7 @@ def _vm_launch(inst, image_ref):
         kwargs["command"] = ["sleep", "infinity"]
     if network:
         kwargs["network"] = network
+    kwargs.update(_parse_ec2_docker_flags(EC2_DOCKER_FLAGS))
     container = client.containers.run(ref, **kwargs)
     global _docker_in_use
     _docker_in_use = True

--- a/tests/test_ec2.py
+++ b/tests/test_ec2.py
@@ -3855,6 +3855,41 @@ def test_ec2_registered_ami_boots_a_container(vm):
     assert inst["PrivateDnsName"] == "ip-172-30-0-9.ec2.internal"
 
 
+def test_ec2_parse_docker_flags():
+    kwargs = ec2mod._parse_ec2_docker_flags(
+        "--privileged -e A=1 --env B=two -v /h:/c:ro --cap-add SYS_ADMIN "
+        "--tmpfs /run:rw,size=64m --add-host me:10.0.0.1 -m 512m --shm-size 128m "
+        "--init=false --bogus-flag xyz")
+    assert kwargs["privileged"] is True
+    assert kwargs["environment"] == {"A": "1", "B": "two"}
+    assert kwargs["volumes"] == ["/h:/c:ro"]
+    assert kwargs["cap_add"] == ["SYS_ADMIN"]
+    assert kwargs["tmpfs"] == {"/run": "rw,size=64m"}
+    assert kwargs["extra_hosts"] == {"me": "10.0.0.1"}
+    assert kwargs["mem_limit"] == "512m"
+    assert kwargs["shm_size"] == "128m"
+    # --init is refused, never forwarded: instance containers always run with init.
+    assert "init" not in kwargs
+    assert ec2mod._parse_ec2_docker_flags("") == {}
+    # Malformed input is ignored rather than raising or exiting inside the server:
+    # a flag missing its value trips argparse's error path, an unbalanced quote
+    # trips shlex.
+    for bad in ("-m", "--cap-add", "'unbalanced"):
+        assert ec2mod._parse_ec2_docker_flags(bad) == {}
+
+
+def test_ec2_docker_flags_reach_the_container(vm, monkeypatch):
+    fake, created = vm
+    monkeypatch.setattr(ec2mod, "EC2_DOCKER_FLAGS", "--privileged --cap-add SYS_ADMIN")
+    ami = _register("example/box:1")
+    iids, _ = _launch(ami)
+    created.extend(iids)
+    run = fake._runs[0]
+    assert run["privileged"] is True
+    assert run["cap_add"] == ["SYS_ADMIN"]
+    assert run["init"] is True
+
+
 def test_ec2_failed_boot_backs_every_record_out(monkeypatch):
     fake = _fake_docker(run_error=RuntimeError("no such image"))
     monkeypatch.setattr(ec2mod, "_get_docker", lambda: fake)


### PR DESCRIPTION
Follows up on #1472's close. Part of #1344. The measurements behind this are in
the #1472 thread; the short version: since 1.5.0 a registered image runs its own
ENTRYPOINT, so a single-service container needs nothing more, but an image that
boots an operating system cannot come up: systemd needs privileges the fixed
launch arguments do not grant, `unshare` fails with `Operation not permitted`, and
the instance terminates at boot. The `systemd-box:1` repro in that thread shows it
without our image.

`EC2_DOCKER_FLAGS` takes a docker-CLI-style string (`--privileged`, `--cap-add`,
`-e`, `-v`, `--tmpfs`, `--add-host`, `-m`, `--shm-size`) and applies it to every
instance container. Unset, nothing changes, so the default path is untouched.
`--init` is refused with a warning: instance containers always run with init, and
an image without an ENTRYPOINT relies on it to reap the appended keepalive
command. Malformed input is warned about and ignored rather than failing the
launch, since argparse's default error path would `sys.exit` inside the server.

The shape mirrors what Lambda already has: `LAMBDA_DOCKER_FLAGS` and its
`_parse_docker_flags` in `lambda_svc.py`. The parser here is deliberately
service-local, like everything else in the file; if you would rather see one
shared parser under `ministack/core/`, say so and this PR grows that refactor.

One commit. `tests/test_ec2.py` is at 185 green: the flags test covers the full
mapping, the `--init` refusal and the malformed inputs (a flag missing its value,
an unbalanced quote), and a fake-daemon case asserts `--privileged --cap-add`
reach `containers.run`. Verified end-to-end on a build of this branch: our
Debian-13 systemd image registered, launched with `EC2_DOCKER_FLAGS=--privileged`,
instance `running`, sshd answering on 22, systemd as PID 1.
