### PR TITLE
fix(iot): fail CreateTopicRule on an unresolvable action role instead of silently dropping the rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+- **IoT Core — an unresolvable action role fails `CreateTopicRule` instead of silently dropping the rule (`AUTH=true`)** — the role check added with the IAM request authorization answered `200 {}` while storing nothing: the store-layer helper returned the error response as a value and both API handlers discarded it, so a client (or a CloudFormation stack) saw success minus its rule. The check now raises through the same door as invalid rule SQL, `CreateTopicRule` / `ReplaceTopicRule` answer `400 InvalidRequestException` (`Unable to assume role: {arn}`) as real IoT does when it cannot assume the role, and the CloudFormation provisioner fails the resource. With `AUTH=false` nothing changes. Reported by @iot-rocket.
+
 ## [1.5.0] — 2026-08-23
 
 ### Added

--- a/ministack/services/iot.py
+++ b/ministack/services/iot.py
@@ -3220,6 +3220,11 @@ class RuleSqlError(ValueError):
     """Rule SQL the engine cannot evaluate, raised by `put_topic_rule`."""
 
 
+class RuleRoleError(ValueError):
+    """An action role ARN IAM cannot resolve (AUTH=true only), raised by
+    `put_topic_rule`."""
+
+
 def _validate_rule_sql(sql: str) -> str | None:
     """Return an error message when the rule SQL cannot be parsed, else None."""
     sql = sql or ""
@@ -3275,7 +3280,9 @@ def put_topic_rule(name: str, payload: dict, *, created_at: float | None = None)
     API or the CloudFormation provisioner. SQL that only *calls* something the
     evaluator lacks is stored (AWS accepts a larger function library than this
     emulator implements, and rejecting it would fail a stack that deploys on
-    AWS) but warns, so the resulting misfire is visible.
+    AWS) but warns, so the resulting misfire is visible. Raises `RuleRoleError`
+    (under AUTH=true) for an action role IAM cannot resolve, through the same
+    two doors — real IoT probes the role at create time and fails the call.
     """
     sql = payload.get("sql", "")
     error = _validate_rule_sql(sql)
@@ -3296,9 +3303,8 @@ def put_topic_rule(name: str, payload: dict, *, created_at: float | None = None)
                 if isinstance(_act_cfg, dict) and "roleArn" in _act_cfg:
                     _iot_role_err = validate_role_arn(_act_cfg["roleArn"])
                     if _iot_role_err:
-                        return error_response_json(
-                            "InvalidRequestException",
-                            f"Unable to assume role: {_act_cfg['roleArn']}", 400)
+                        raise RuleRoleError(
+                            f"Unable to assume role: {_act_cfg['roleArn']}")
 
     rule = {
         "ruleName": name,
@@ -3350,6 +3356,8 @@ def _create_topic_rule(name: str, payload: dict) -> tuple:
         put_topic_rule(name, payload)
     except RuleSqlError as exc:
         return error_response_json("SqlParseException", str(exc), 400)
+    except RuleRoleError as exc:
+        return error_response_json("InvalidRequestException", str(exc), 400)
     return json_response({})
 
 
@@ -3360,6 +3368,8 @@ def _replace_topic_rule(name: str, payload: dict) -> tuple:
         put_topic_rule(name, payload)
     except RuleSqlError as exc:
         return error_response_json("SqlParseException", str(exc), 400)
+    except RuleRoleError as exc:
+        return error_response_json("InvalidRequestException", str(exc), 400)
     return json_response({})
 
 

--- a/tests/test_iot.py
+++ b/tests/test_iot.py
@@ -1164,6 +1164,91 @@ def test_iot_create_topic_rule_unsupported_where_rejected(iot_client):
     assert ei.value.response["Error"]["Code"] == "SqlParseException"
 
 
+def test_iot_topic_rule_role_validated_under_auth(monkeypatch):
+    """Under AUTH=true a rule naming an action role IAM cannot resolve is
+    refused 400 `InvalidRequestException` ("Unable to assume role: ..."), as
+    real IoT does by probing the role at create time — and the rule must NOT
+    be stored. In-process because the shared test server runs AUTH=false:
+    `validate_role_arn` reads `ministack.app.AUTH` at call time, so the
+    monkeypatch reaches it."""
+    import json as _json
+
+    import ministack.app as _app
+    from ministack.services import iam as _iam
+    from ministack.services import iot as _iot
+
+    monkeypatch.setattr(_app, "AUTH", True)
+    name = _rule_name()
+    bad = {
+        "sql": "SELECT * FROM 'a'",
+        "actions": [{"sqs": {
+            "queueUrl": "http://localhost/000000000000/q",
+            "roleArn": "arn:aws:iam::000000000000:role/absent-role",
+        }}],
+    }
+    try:
+        # Create door: 400, nothing stored.
+        status, _, body = _iot._create_topic_rule(name, bad)
+        assert status == 400
+        err = _json.loads(body)
+        assert err["__type"] == "InvalidRequestException"
+        assert "Unable to assume role" in err["message"]
+        assert name not in _iot._topic_rules
+
+        # An existing role passes the same check.
+        _iam._roles.setdefault("probe-rule-role", {"RoleName": "probe-rule-role"})
+        good = {
+            "sql": "SELECT * FROM 'a'",
+            "actions": [{"sqs": {
+                "queueUrl": "http://localhost/000000000000/q",
+                "roleArn": "arn:aws:iam::000000000000:role/probe-rule-role",
+            }}],
+        }
+        status, _, _b = _iot._create_topic_rule(name, good)
+        assert status == 200
+        assert name in _iot._topic_rules
+
+        # Replace door: same 400, the stored rule stays what it was.
+        status, _, body = _iot._replace_topic_rule(name, bad)
+        assert status == 400
+        assert _json.loads(body)["__type"] == "InvalidRequestException"
+        assert (_iot._topic_rules[name]["actions"][0]["sqs"]["roleArn"]
+                == good["actions"][0]["sqs"]["roleArn"])
+
+        # CFN door: the store-layer helper raises, so the provisioner (which
+        # calls put_topic_rule directly) fails the resource instead of
+        # green-lighting a stack minus its rule.
+        with pytest.raises(_iot.RuleRoleError):
+            _iot.put_topic_rule(name + "cfn", bad)
+        assert (name + "cfn") not in _iot._topic_rules
+    finally:
+        _iot._topic_rules.pop(name, None)
+        _iam._roles.pop("probe-rule-role", None)
+
+
+def test_iot_topic_rule_role_not_validated_without_auth(monkeypatch):
+    """With AUTH=false (the default) an unresolvable role is stored as before —
+    the check is authorization-mode fidelity, not a new default gate."""
+    import ministack.app as _app
+    from ministack.services import iot as _iot
+
+    monkeypatch.setattr(_app, "AUTH", False)
+    name = _rule_name()
+    payload = {
+        "sql": "SELECT * FROM 'a'",
+        "actions": [{"sqs": {
+            "queueUrl": "http://localhost/000000000000/q",
+            "roleArn": "arn:aws:iam::000000000000:role/absent-role",
+        }}],
+    }
+    try:
+        status, _, _b = _iot._create_topic_rule(name, payload)
+        assert status == 200
+        assert name in _iot._topic_rules
+    finally:
+        _iot._topic_rules.pop(name, None)
+
+
 def test_iot_create_topic_rule_accepts_or_and_parentheses(iot_client):
     """`OR` and parenthesised groups are valid AWS rule SQL — rejecting them
     would fail rules that deploy fine on AWS."""


### PR DESCRIPTION
Part of #1417; the measurements that found this are there. The role check added
with the IAM request authorization work generates the right error and never
sends it: `put_topic_rule` returns the `error_response_json(...)` tuple as a
value, and both `_create_topic_rule` and `_replace_topic_rule` discard the
helper's return, catch only `RuleSqlError`, and answer `200 {}`. Under
`AUTH=true` a rule naming a role IAM cannot resolve is therefore silently
dropped: the client sees success, `GetTopicRule` answers
`ResourceNotFoundException`, and a CloudFormation stack through the same helper
goes green minus its rule.

The fix routes the role check through the same door the SQL check already uses:
`put_topic_rule` raises a `RuleRoleError` next to `RuleSqlError`, the two API
handlers map it to `400 InvalidRequestException` (`Unable to assume role:
{arn}`, the message the check already built, matching what real IoT answers
when it cannot assume the role at create time), and the CloudFormation
provisioner, which calls `put_topic_rule` directly, fails the resource the way
it does for invalid SQL. With `AUTH=false` nothing changes.

`tests/test_iot.py` is at 423 passed. The new cases run in-process because the
test server runs `AUTH=false`: `validate_role_arn` reads `ministack.app.AUTH`
at call time, so a monkeypatch reaches it. Covered: the create door (400, body
`__type`, nothing stored), the same payload accepted once the role exists, the
replace door (400 and the stored rule keeps its previous role), the raise on
the store-layer helper itself (the CFN door), and `AUTH=false` accepting an
unresolvable role unchanged.

One note from checking whether the pattern repeats: the other eight
`validate_role_arn` call sites (Lambda, ECS, EKS, Batch, Glue, Step Functions,
Cognito, Firehose) all sit directly in handlers and return their error tuples
correctly, so this was the only swallowed one. An AST sweep for the wider shape
(an error-returning function called with its result discarded) mostly finds
best-effort deletes in the CloudFormation provisioners, plus a handful of
create paths there (event bus, CodeBuild project, ECS and Cloud Map service)
and the EventBridge to Step Functions dispatch, where an error tuple would also
vanish. Those have a much smaller blast radius and are not touched here; happy
to write them up separately if that is useful.
