### PR TITLE
fix(ecs): do not publish host ports for awsvpc tasks

### DIFF
--- a/ministack/services/ecs.py
+++ b/ministack/services/ecs.py
@@ -1314,10 +1314,15 @@ def _run_task(data):
                 if "command" in container_override:
                     effective_cdef["command"] = container_override["command"]
 
+                # awsvpc tasks get their own network namespace — an ENI in AWS — so
+                # container ports are never published on the host. Publishing them
+                # makes two tasks that share a container port collide on the host,
+                # which cannot happen on Fargate. Only bridge/host mode publishes.
                 port_bindings = {}
-                for pm in cdef.get("portMappings", []):
-                    host_port = pm.get("hostPort", pm.get("containerPort"))
-                    port_bindings[f"{pm['containerPort']}/tcp"] = host_port
+                if td.get("networkMode") != "awsvpc":
+                    for pm in cdef.get("portMappings", []):
+                        host_port = pm.get("hostPort", pm.get("containerPort"))
+                        port_bindings[f"{pm['containerPort']}/tcp"] = host_port
 
                 host_mode = td.get("networkMode") == "host"
                 metadata_token = _register_metadata(

--- a/tests/test_ecs.py
+++ b/tests/test_ecs.py
@@ -1397,3 +1397,77 @@ def test_ecs_run_task_does_not_block_the_loop(ecs):
             except Exception:
                 pass
     probe.assert_responsive("ECS RunTask")
+
+
+def _fake_docker_recorder(run_impl=None):
+    """Docker double that records containers.run kwargs (see command-override tests)."""
+    class FakeContainers:
+        def __init__(self):
+            self.calls = []
+
+        def get(self, _name):
+            raise Exception("not found")
+
+        def list(self, *args, **kwargs):
+            return []
+
+        def run(self, image, **kwargs):
+            self.calls.append((image, kwargs))
+            if run_impl is not None:
+                return run_impl(image, kwargs)
+            return SimpleNamespace(id=f"container-{len(self.calls):012d}")
+
+    fake_containers = FakeContainers()
+    return fake_containers, SimpleNamespace(containers=fake_containers)
+
+
+def test_ecs_awsvpc_task_does_not_publish_host_ports(monkeypatch):
+    """awsvpc tasks get their own ENI, so container ports are not bound on the host.
+
+    Publishing them means two tasks sharing a container port collide on the host —
+    something that cannot happen on Fargate.
+    """
+    from ministack.services import ecs as _ecs
+
+    fake_containers, fake_docker = _fake_docker_recorder()
+    monkeypatch.setattr(_ecs, "_get_docker", lambda: fake_docker)
+
+    _ecs._register_task_definition({
+        "family": "awsvpc-ports-td",
+        "networkMode": "awsvpc",
+        "containerDefinitions": [{
+            "name": "web",
+            "image": "busybox",
+            "portMappings": [{"containerPort": 80, "hostPort": 80, "protocol": "tcp"}],
+        }],
+    })
+    _ecs._run_task({"cluster": "awsvpc-ports-c", "taskDefinition": "awsvpc-ports-td"})
+
+    assert fake_containers.calls, "expected the container to be launched"
+    _image, kwargs = fake_containers.calls[0]
+    assert not kwargs.get("ports"), (
+        f"awsvpc task must not publish host ports, got {kwargs.get('ports')!r}"
+    )
+
+
+def test_ecs_bridge_task_still_publishes_host_ports(monkeypatch):
+    """bridge networking does publish to the host — the awsvpc fix must not affect it."""
+    from ministack.services import ecs as _ecs
+
+    fake_containers, fake_docker = _fake_docker_recorder()
+    monkeypatch.setattr(_ecs, "_get_docker", lambda: fake_docker)
+
+    _ecs._register_task_definition({
+        "family": "bridge-ports-td",
+        "networkMode": "bridge",
+        "containerDefinitions": [{
+            "name": "web",
+            "image": "busybox",
+            "portMappings": [{"containerPort": 80, "hostPort": 8080, "protocol": "tcp"}],
+        }],
+    })
+    _ecs._run_task({"cluster": "bridge-ports-c", "taskDefinition": "bridge-ports-td"})
+
+    _image, kwargs = fake_containers.calls[0]
+    assert kwargs.get("ports") == {"80/tcp": 8080}
+


### PR DESCRIPTION
An `awsvpc` task gets its own network namespace — an ENI on Fargate — so its
container ports are never bound on the host. RunTask published them anyway, which
made two tasks that share a container port collide: the second got
`Bind for 0.0.0.0:80 failed: port is already allocated` from Docker, something that
cannot happen on Fargate.

A writer/reader pair of ECS services built from the same image, each mapping
container port 80 under `awsvpc` — the shape a Terraform ECS + ALB module produces —
could therefore never both run.

Port publishing is now limited to `bridge` and `host` networking, which do bind on
the host.

### Tests

Both directions, so the bridge path cannot regress:

- `test_ecs_awsvpc_task_does_not_publish_host_ports`
- `test_ecs_bridge_task_still_publishes_host_ports`

`pytest tests/test_ecs.py tests/test_ecs_metadata.py -n 4 --dist=loadfile -m "not serial"` passes.

Found running a Terraform ECS + ALB service pair against MiniStack.
