### PR TITLE
fix(cloudformation): keep pre-existing resources on update rollback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to MiniStack will be documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 Versioning follows [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+- **CloudFormation — a failed update keeps the pre-existing resources when it rolls back** — the rollback of a failed stack update deleted every resource the run had touched, and a run touches every resource in the template: unchanged resources and resources updated in place went down together with what the update had actually created, while the restored stack still recorded them. The rollback now deletes only what the update created and replacements under a new physical id; a resource that kept its physical id is left standing. Not covered: an in-place change is not reverted, and a replacement's old resource, already removed by the update, is not recreated. Contributed by @iot-rocket.
+
 ## [1.5.7] — 2026-09-04
 
 ### Added

--- a/ministack/services/cloudformation/stacks.py
+++ b/ministack/services/cloudformation/stacks.py
@@ -244,11 +244,24 @@ async def _deploy_stack_async(stack_name: str, stack_id: str, template: dict,
                        "Rollback requested", stack_id)
 
             rollback_delete_failures = []
+            previous_resources = (
+                previous_stack.get("_resources", {})
+                if is_update and previous_stack else {}
+            )
             for logical_id in reversed(created_in_this_run):
                 res = provisioned_resources.get(logical_id, {})
                 rtype = res.get("ResourceType", "")
                 pid = res.get("PhysicalResourceId", "")
                 res_props = res.get("Properties", {})
+                prev = previous_resources.get(logical_id)
+                if prev is not None and prev.get("PhysicalResourceId") == pid:
+                    # The resource existed before this update and kept its
+                    # identity (untouched, or updated in place), so it is not
+                    # something this run created: deleting it would destroy a
+                    # resource the restored stack still records. Only new
+                    # resources and replacements under a new physical id are
+                    # undone. An in-place change is not reverted here.
+                    continue
                 try:
                     if _is_custom_resource(rtype):
                         await run_reentrant(

--- a/tests/test_cfn.py
+++ b/tests/test_cfn.py
@@ -10896,3 +10896,137 @@ def test_cfn_cognito_user_pool_enabled_mfas(cfn, cognito_idp):
 
     cfn.delete_stack(StackName="cfn-enabled-mfas")
     _wait_stack(cfn, "cfn-enabled-mfas")
+
+
+def test_cfn_update_rollback_keeps_the_resources_that_existed_before(cfn, sqs, ddb):
+    """A failed update rolls back only what the update created. The queue
+    existed before the update and kept its physical id through an in-place
+    change, so the rollback leaves it alone; the queue the update added is
+    deleted; the table, whose attribute type change is refused under its
+    custom name, is what fails the update. The in-place change itself is not
+    reverted: the queue keeps the new VisibilityTimeout while the stack
+    records the old template."""
+    uid = _uuid_mod.uuid4().hex[:8]
+    stack_name = f"cfn-rb-keep-{uid}"
+    queue_name = f"cfn-rb-keep-{uid}"
+    added_name = f"cfn-rb-added-{uid}"
+    table_name = f"cfn-rb-keep-{uid}"
+
+    def template(visibility, key_type, with_added):
+        resources = {
+            "Queue": {"Type": "AWS::SQS::Queue", "Properties": {
+                "QueueName": queue_name, "VisibilityTimeout": visibility}},
+            "Table": {"Type": "AWS::DynamoDB::Table", "DependsOn": "Queue", "Properties": {
+                "TableName": table_name,
+                "AttributeDefinitions": [{"AttributeName": "pk", "AttributeType": key_type}],
+                "KeySchema": [{"AttributeName": "pk", "KeyType": "HASH"}],
+                "BillingMode": "PAY_PER_REQUEST",
+            }},
+        }
+        if with_added:
+            resources["Added"] = {"Type": "AWS::SQS::Queue", "DependsOn": "Queue",
+                                  "Properties": {"QueueName": added_name}}
+            resources["Table"]["DependsOn"] = "Added"
+        return json.dumps({"Resources": resources})
+
+    cfn.create_stack(StackName=stack_name, TemplateBody=template(30, "S", False))
+    try:
+        stack = _wait_stack(cfn, stack_name)
+        assert stack["StackStatus"] == "CREATE_COMPLETE", stack.get("StackStatusReason")
+        queue_url = sqs.get_queue_url(QueueName=queue_name)["QueueUrl"]
+        sqs.send_message(QueueUrl=queue_url, MessageBody="kept")
+
+        cfn.update_stack(StackName=stack_name, TemplateBody=template(45, "N", True))
+        stack = _wait_stack(cfn, stack_name)
+        assert stack["StackStatus"] == "UPDATE_ROLLBACK_COMPLETE", stack.get("StackStatusReason")
+        events = cfn.describe_stack_events(StackName=stack_name)["StackEvents"]
+        assert not [e for e in events if e["LogicalResourceId"] == "Queue"
+                    and e["ResourceStatus"].startswith("DELETE")]
+        assert [e for e in events if e["LogicalResourceId"] == "Added"
+                and e["ResourceStatus"] == "DELETE_COMPLETE"]
+
+        assert sqs.get_queue_url(QueueName=queue_name)["QueueUrl"] == queue_url
+        attributes = sqs.get_queue_attributes(
+            QueueUrl=queue_url, AttributeNames=["VisibilityTimeout", "ApproximateNumberOfMessages"]
+        )["Attributes"]
+        assert attributes["ApproximateNumberOfMessages"] == "1"
+        assert attributes["VisibilityTimeout"] == "45"  # the in-place change is not reverted
+        with pytest.raises(ClientError):
+            sqs.get_queue_url(QueueName=added_name)
+        table = ddb.describe_table(TableName=table_name)["Table"]
+        assert table["AttributeDefinitions"] == [{"AttributeName": "pk", "AttributeType": "S"}]
+        resources = {r["LogicalResourceId"]: r for r in cfn.describe_stack_resources(
+            StackName=stack_name)["StackResources"]}
+        assert set(resources) == {"Queue", "Table"}
+        assert resources["Queue"]["PhysicalResourceId"].endswith(f"/{queue_name}")
+        assert resources["Table"]["PhysicalResourceId"] == table_name
+    finally:
+        _delete_cfn_test_stack(cfn, stack_name)
+    with pytest.raises(ClientError):
+        sqs.get_queue_url(QueueName=queue_name)
+
+
+def test_cfn_update_rollback_deletes_the_replacement_and_restores_the_old_record(cfn, sqs, ddb):
+    """A resource replaced under a new physical id during a failed update has
+    the replacement deleted on rollback, and the restored stack record points
+    at the old physical id again. The queue is renamed, which is a replacement
+    (QueueName is create-only); the table, whose attribute type change is
+    refused under its custom name, is what fails the update.
+
+    AWS, "Understand update behaviors of stack resources": a replacement
+    "recreates the resource during an update, which also generates a new
+    physical ID. CloudFormation usually creates the replacement resource
+    first, changes references from other dependent resources to point to the
+    replacement resource, and then deletes the old resource." And on a failed
+    operation ("Managing AWS resources as a single unit"): "CloudFormation
+    rolls the stack back and automatically deletes any resources that were
+    created."
+
+    The emulator's replacement deletes the old queue as soon as the new one
+    exists, so the rollback cannot bring it back: the restored record names a
+    queue that no longer exists. That is the disclosed limit this test pins.
+    """
+    uid = _uuid_mod.uuid4().hex[:8]
+    stack_name = f"cfn-rb-replace-{uid}"
+    old_name = f"cfn-rb-old-{uid}"
+    new_name = f"cfn-rb-new-{uid}"
+    table_name = f"cfn-rb-replace-{uid}"
+
+    def template(queue_name, key_type):
+        return json.dumps({"Resources": {
+            "Queue": {"Type": "AWS::SQS::Queue", "Properties": {"QueueName": queue_name}},
+            "Table": {"Type": "AWS::DynamoDB::Table", "DependsOn": "Queue", "Properties": {
+                "TableName": table_name,
+                "AttributeDefinitions": [{"AttributeName": "pk", "AttributeType": key_type}],
+                "KeySchema": [{"AttributeName": "pk", "KeyType": "HASH"}],
+                "BillingMode": "PAY_PER_REQUEST",
+            }},
+        }})
+
+    cfn.create_stack(StackName=stack_name, TemplateBody=template(old_name, "S"))
+    try:
+        stack = _wait_stack(cfn, stack_name)
+        assert stack["StackStatus"] == "CREATE_COMPLETE", stack.get("StackStatusReason")
+        old_url = sqs.get_queue_url(QueueName=old_name)["QueueUrl"]
+
+        cfn.update_stack(StackName=stack_name, TemplateBody=template(new_name, "N"))
+        stack = _wait_stack(cfn, stack_name)
+        assert stack["StackStatus"] == "UPDATE_ROLLBACK_COMPLETE", stack.get("StackStatusReason")
+        events = [e for e in cfn.describe_stack_events(StackName=stack_name)["StackEvents"]
+                  if e["LogicalResourceId"] == "Queue"]
+        deleted = [e for e in events if e["ResourceStatus"] == "DELETE_COMPLETE"]
+        assert [e["PhysicalResourceId"] for e in deleted] == [f"{old_url.rsplit('/', 1)[0]}/{new_name}"]
+
+        with pytest.raises(ClientError):
+            sqs.get_queue_url(QueueName=new_name)
+        with pytest.raises(ClientError):  # the replacement already removed it; not restored
+            sqs.get_queue_url(QueueName=old_name)
+        resources = {r["LogicalResourceId"]: r for r in cfn.describe_stack_resources(
+            StackName=stack_name)["StackResources"]}
+        assert set(resources) == {"Queue", "Table"}
+        assert resources["Queue"]["PhysicalResourceId"] == old_url
+        assert resources["Table"]["PhysicalResourceId"] == table_name
+        table = ddb.describe_table(TableName=table_name)["Table"]
+        assert table["AttributeDefinitions"] == [{"AttributeName": "pk", "AttributeType": "S"}]
+    finally:
+        _delete_cfn_test_stack(cfn, stack_name)


### PR DESCRIPTION
Part of #1601 (A2). Separate from #1585: a bug in the update rollback, not a missing update handler.

## What

`_deploy_stack_async()` in `ministack/services/cloudformation/stacks.py` collected every resource an update
run processed and, on a failure, deleted all of them. A run processes every resource in the template, so the
rollback deleted the unchanged resources and the ones updated in place under their existing physical id,
together with what the failed update had actually created. The restored stack still recorded them, pointing at
resources that no longer existed.

The rollback now compares each resource with the pre-update record: a physical id that matches existed before
the run and stays. A logical id the previous stack did not have, or one that now carries a different physical
id, is what the update created, and only those are deleted. Thirteen lines.

Three limits stay as they are, and the tests pin them:

1. An in-place property change is not reverted; the resource keeps the updated configuration while the stack
   records the previous template.
2. A replacement that succeeded earlier in the failed run is not restored. The emulator's replacement deletes
   the old resource as soon as the new one exists, so the rollback removes the replacement and the restored
   record points at a physical id the update already removed.
3. Together with the `AWS::Lambda::Permission` update handler (#1585 batch), a failed update after a permission
   change ends with no statement: that handler removes the old statement before adding the new one, and the
   rollback removes the new one.

## Reproduction (v1.5.7)

Two resources, an SQS queue and a DynamoDB table under a custom name whose key type changes (CloudFormation
refuses that); the queue's `VisibilityTimeout` changes in the same update.

Before: stack `UPDATE_ROLLBACK_COMPLETE`, `GetQueueUrl` answers `NonExistentQueue`, `DescribeStackResources`
still lists the queue. After: the queue exists with the updated timeout, the table is back at its previous key
type, stack `UPDATE_ROLLBACK_COMPLETE`.

## Tests

`tests/test_cfn.py`, live like the rest of the file, each stack cleaned up in a `finally`:

- `test_cfn_update_rollback_keeps_the_resources_that_existed_before`: the scenario above plus a queue the
  failed update adds; the pre-existing queue survives with its message and keeps the in-place change (limit 1),
  the added queue is deleted, the table is restored.
- `test_cfn_update_rollback_deletes_the_replacement_and_restores_the_old_record`: a renamed queue (create-only
  `QueueName`, replacement under a new URL) in a failing update; the replacement is deleted, the restored record
  names the old URL, the old queue is gone (limit 2).

Whole `tests/test_cfn.py` green on a private server.

## References

- Update rollback: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks.html
- Replacement order (create first, then delete): https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html
- #1534, the in-place update handlers this rollback path runs after.
