### PR TITLE
fix(cloudformation): DeleteChangeSet of a missing change set succeeds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to MiniStack will be documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 Versioning follows [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+- **CloudFormation — `DeleteChangeSet` of a change set that does not exist succeeds** — it answered `ChangeSetNotFound` (404), and the response of a successful delete carried no `DeleteChangeSetResult` element, so boto3 could not parse it at all. The CDK removes a possible leftover `cdk-deploy-change-set` before every deploy of an existing stack, addresses the stack by its ARN, and only tolerates `ChangeSetNotFoundException`, so every `cdk deploy` of an already deployed stack aborted with `ChangeSet [cdk-deploy-change-set] does not exist`. A real account answers that delete with a plain success; the stack is now resolved by name or stack ID first, and a stack that does not exist is still a `ValidationError`. Contributed by @iot-rocket.
+
 ## [1.5.7] — 2026-09-04
 
 ### Added

--- a/ministack/services/cloudformation/changesets.py
+++ b/ministack/services/cloudformation/changesets.py
@@ -388,14 +388,28 @@ def _execute_change_set(params):
 
 def _delete_change_set(params):
     from ministack.services.cloudformation import _change_sets
+    from ministack.services.cloudformation.handlers import _resolve_stack
     cs_name = _p(params, "ChangeSetName")
     stack_name = _p(params, "StackName")
-    cs_id, cs = _find_change_set(cs_name, stack_name)
-    if not cs_id:
-        return _error("ChangeSetNotFound",
-                      f"ChangeSet [{cs_name}] does not exist", 404)
-    _change_sets.pop(cs_id, None)
-    return _xml(200, "DeleteChangeSetResponse", "")
+    # StackName is "the name or the unique stack ID", and the CDK addresses a
+    # stack it has already read by ARN, so resolve it first and look the change
+    # set up under the stack's name. A stack that does not exist is a
+    # ValidationError, as on AWS -- and a deleted stack counts as one, since it
+    # is addressable only by stack id.
+    stack = _resolve_stack(stack_name) if stack_name else None
+    if stack_name and (not stack or stack.get("StackStatus") == "DELETE_COMPLETE"):
+        return _error("ValidationError",
+                      f"Stack [{stack_name}] does not exist")
+    cs_id, _cs = _find_change_set(cs_name, stack["StackName"] if stack else stack_name)
+    # Real CloudFormation answers a delete of a change set that does not exist
+    # (on a stack that does) with a plain success, and the CDK relies on that:
+    # before every deploy of an existing stack it removes a possible leftover
+    # `cdk-deploy-change-set` and only tolerates a `ChangeSetNotFoundException`
+    # -- so the 404 answered here aborted every `cdk deploy` of an already
+    # deployed stack.
+    if cs_id:
+        _change_sets.pop(cs_id, None)
+    return _xml(200, "DeleteChangeSetResponse", "<DeleteChangeSetResult/>")
 
 
 # --- ListChangeSets ---

--- a/tests/test_cfn.py
+++ b/tests/test_cfn.py
@@ -10896,3 +10896,63 @@ def test_cfn_cognito_user_pool_enabled_mfas(cfn, cognito_idp):
 
     cfn.delete_stack(StackName="cfn-enabled-mfas")
     _wait_stack(cfn, "cfn-enabled-mfas")
+
+
+def test_cfn_delete_change_set_existing_succeeds(cfn):
+    """DeleteChangeSet of an existing change set succeeds -- by stack name and
+    by stack ID -- and the response parses (boto3 needs the
+    DeleteChangeSetResult element; the success answer used to lack it)."""
+    name = f"cfn-delcs-ok-{_uuid_mod.uuid4().hex[:8]}"
+    cfn.create_stack(StackName=name, TemplateBody=json.dumps(
+        {"Resources": {"Q": {"Type": "AWS::SQS::Queue"}}}))
+    try:
+        stack = _wait_stack(cfn, name)
+        assert stack["StackStatus"] == "CREATE_COMPLETE", stack.get("StackStatusReason")
+        stack_id = stack["StackId"]
+        update = json.dumps({"Resources": {
+            "Q": {"Type": "AWS::SQS::Queue"},
+            "P": {"Type": "AWS::SSM::Parameter", "Properties": {
+                "Name": f"/{name}/p", "Type": "String", "Value": "v"}}}})
+        for cs_name, by in (("cs-by-name", name), ("cs-by-id", stack_id)):
+            cfn.create_change_set(StackName=name, ChangeSetName=cs_name,
+                                  TemplateBody=update, ChangeSetType="UPDATE")
+            assert cfn.describe_change_set(
+                StackName=name, ChangeSetName=cs_name)["Status"] == "CREATE_COMPLETE"
+            resp = cfn.delete_change_set(StackName=by, ChangeSetName=cs_name)
+            assert resp["ResponseMetadata"]["HTTPStatusCode"] == 200
+            with pytest.raises(ClientError) as exc:
+                cfn.describe_change_set(StackName=name, ChangeSetName=cs_name)
+            assert exc.value.response["Error"]["Code"] == "ChangeSetNotFound"
+        names = [c["ChangeSetName"] for c in cfn.list_change_sets(StackName=name)["Summaries"]]
+        assert names == []
+    finally:
+        _delete_cfn_test_stack(cfn, name)
+
+
+def test_cfn_delete_change_set_missing_is_idempotent(cfn):
+    """DeleteChangeSet of a change set that does not exist succeeds on an
+    existing stack, addressed by name or by stack ID (measured on a real
+    account) -- the CDK removes a possible leftover `cdk-deploy-change-set`
+    before every deploy, addresses the stack by ARN, and aborts on any error
+    other than ChangeSetNotFoundException. A missing stack is still a
+    ValidationError, and so is a deleted one."""
+    name = f"cfn-delcs-idem-{_uuid_mod.uuid4().hex[:8]}"
+    cfn.create_stack(StackName=name, TemplateBody=json.dumps(
+        {"Resources": {"Q": {"Type": "AWS::SQS::Queue"}}}))
+    try:
+        stack = _wait_stack(cfn, name)
+        assert stack["StackStatus"] == "CREATE_COMPLETE", stack.get("StackStatusReason")
+        for by in (name, stack["StackId"]):
+            resp = cfn.delete_change_set(StackName=by, ChangeSetName="cdk-deploy-change-set")
+            assert resp["ResponseMetadata"]["HTTPStatusCode"] == 200
+        with pytest.raises(ClientError) as exc:
+            cfn.describe_change_set(StackName=name, ChangeSetName="cdk-deploy-change-set")
+        assert exc.value.response["Error"]["Code"] == "ChangeSetNotFound"
+        with pytest.raises(ClientError) as exc:
+            cfn.delete_change_set(StackName=f"{name}-nope", ChangeSetName="x")
+        assert exc.value.response["Error"]["Code"] == "ValidationError"
+    finally:
+        _delete_cfn_test_stack(cfn, name)
+    with pytest.raises(ClientError) as exc:
+        cfn.delete_change_set(StackName=name, ChangeSetName="cdk-deploy-change-set")
+    assert exc.value.response["Error"]["Code"] == "ValidationError"


### PR DESCRIPTION
Part of #1601 (A1).

## What

`DeleteChangeSet` for a change set that does not exist answered `ChangeSetNotFound` with a 404. On a real
account the same call on an existing stack succeeds with no output (measured 2026-09-02, eu-central-1); only a
stack that does not exist is a `ValidationError`, which this keeps (a deleted stack counts as one, since it is
addressable only by stack ID, the rule the rest of the module applies). The API reference lists only
`InvalidChangeSetStatus` as an error for this operation.

The CDK depends on that: before every deploy of an already deployed stack it runs "Removing existing change set
with name cdk-deploy-change-set if it exists" and tolerates only `ChangeSetNotFoundException`. With the 404 the
deploy aborts:

```
[11:33:08] my-service-dev: deploying...
[11:33:08] Removing existing change set with name cdk-deploy-change-set if it exists
ChangeSet [cdk-deploy-change-set] does not exist
```

(aws-cdk 2.1128.0, `cdklocal deploy <stack>`; the first deploy of a stack is unaffected because there is no
stack to clean up, which is why `cdk deploy --all` on a fresh emulator works and the second deploy does not.)

The CDK addresses the stack by its ARN, so the stack is resolved first through `_resolve_stack` from #1617
(name or unique stack ID) and the change set is looked up under the resolved name; with the old name-only
comparison a delete by ARN of an existing set answered success and deleted nothing.

While adding the test: the success response was `<DeleteChangeSetResponse>` without a `DeleteChangeSetResult`
element, so boto3 raised `KeyError: 'DeleteChangeSetResult'` on every successful delete as well. Both returns
now carry the element.

## Tests

`tests/test_cfn.py`, live, cleaned up in a `finally`:

- `test_cfn_delete_change_set_existing_succeeds`: two change sets, one deleted by stack name and one by stack
  ID; the response parses, `DescribeChangeSet` answers `ChangeSetNotFound`, `ListChangeSets` is empty.
- `test_cfn_delete_change_set_missing_is_idempotent`: a missing set deleted by name and by stack ID succeeds;
  a missing stack and a deleted stack are a `ValidationError`.

Both fail on the previous guard. Whole `tests/test_cfn.py` green.

## References

- https://docs.aws.amazon.com/AWSCloudFormation/latest/APIReference/API_DeleteChangeSet.html
- #1617, `_resolve_stack`.
