### PR TITLE
fix(cloudformation): enforce Capabilities under AUTH=true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to MiniStack will be documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 Versioning follows [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+- **CloudFormation — `Capabilities` are enforced under `AUTH=true`** — `CreateStack`, `UpdateStack` and `CreateChangeSet` accepted a template with IAM resources or a `Transform` whatever the request acknowledged, so a deploy that CloudFormation refuses with `InsufficientCapabilitiesException` went through. With `AUTH=true` they now answer that error (HTTP 400, `Requires capabilities : [CAPABILITY_IAM]`, measured) and create nothing: an IAM resource needs `CAPABILITY_IAM` or `CAPABILITY_NAMED_IAM`, one with a custom name `CAPABILITY_NAMED_IAM`, a template with a `Transform` `CAPABILITY_AUTO_EXPAND` on `CreateStack` and `UpdateStack` (not on a change set, as the API documents). Without `AUTH` nothing changes; `GetTemplateSummary` keeps reporting the same set. Contributed by @iot-rocket.
+
 ## [1.5.9] — 2026-09-08
 
 ### Added

--- a/ministack/services/cloudformation/changesets.py
+++ b/ministack/services/cloudformation/changesets.py
@@ -77,7 +77,10 @@ def _resolve_props_for_diff(template, params, stack_name, stack_id):
 
 def _create_change_set(params):
     from ministack.services.cloudformation import _change_sets, _stack_events, _stacks
-    from ministack.services.cloudformation.handlers import _resolve_stack
+    from ministack.services.cloudformation.handlers import (
+        _check_capabilities,
+        _resolve_stack,
+    )
     stack_name = _p(params, "StackName")
     cs_name = _p(params, "ChangeSetName")
     cs_type = _p(params, "ChangeSetType", "UPDATE")
@@ -166,19 +169,28 @@ def _create_change_set(params):
         if not template_body:
             template_body = stack.get("_template_body", "{}")
 
-    def _rejected(message):
+    def _rejected(reason):
         # A rejected CreateChangeSet leaves no stack behind on AWS; drop the
         # REVIEW_IN_PROGRESS placeholder created above for CREATE sets.
+        # ``reason`` is a ValidationError message or a ready error response.
         if cs_type == "CREATE":
             _stacks.pop(stack_name, None)
             _stack_events.pop(stack_id, None)
-        return _error("ValidationError", message)
+        if isinstance(reason, tuple):
+            return reason
+        return _error("ValidationError", reason)
 
     try:
-        template = _parse_template(template_body)
+        template = sent = _parse_template(template_body)
         template = _apply_sam_transform_if_applicable(template)
     except Exception as e:
         return _rejected(f"Template format error: {e}")
+
+    # Checked after the transform, as CreateStack and UpdateStack do.
+    # CAPABILITY_AUTO_EXPAND does not apply to a change set
+    # (API_CreateChangeSet), so only the IAM rule runs here.
+    if caps_error := _check_capabilities(sent, template, params, macros=False):
+        return _rejected(caps_error)
 
     try:
         param_values = _resolve_parameters(

--- a/ministack/services/cloudformation/handlers.py
+++ b/ministack/services/cloudformation/handlers.py
@@ -51,6 +51,151 @@ from .stacks import (
 logger = logging.getLogger("cloudformation")
 
 
+# GetTemplateSummary's rule, kept as it was: every ``AWS::IAM::*`` type needs
+# a capability, and these name properties make it CAPABILITY_NAMED_IAM.
+_NAMED_IAM_PROPS = {
+    "AWS::IAM::Role": "RoleName",
+    "AWS::IAM::User": "UserName",
+    "AWS::IAM::Group": "GroupName",
+    "AWS::IAM::Policy": "PolicyName",
+    "AWS::IAM::ManagedPolicy": "ManagedPolicyName",
+    "AWS::IAM::InstanceProfile": "InstanceProfileName",
+}
+
+# The enforcement rule, from the ``Capabilities`` parameter of API_CreateStack:
+# these eight types "require you to specify either the CAPABILITY_IAM or
+# CAPABILITY_NAMED_IAM capability", and "If you have IAM resources with
+# custom names, you must specify CAPABILITY_NAMED_IAM". ``AWS::IAM::Policy``
+# is not in the named map: its ``PolicyName`` is a required property
+# (aws-resource-iam-policy.html), not a custom name.
+_CAPABILITY_IAM_TYPES = frozenset({
+    "AWS::IAM::AccessKey",
+    "AWS::IAM::Group",
+    "AWS::IAM::InstanceProfile",
+    "AWS::IAM::ManagedPolicy",
+    "AWS::IAM::Policy",
+    "AWS::IAM::Role",
+    "AWS::IAM::User",
+    "AWS::IAM::UserToGroupAddition",
+})
+_CAPABILITY_NAMED_PROPS = {
+    rtype: prop for rtype, prop in _NAMED_IAM_PROPS.items()
+    if rtype != "AWS::IAM::Policy"
+}
+
+
+def _uses_embedded_macro(template):
+    """True when a section of the template (other than ``Parameters`` and
+    ``AWSTemplateFormatVersion``) contains an ``Fn::Transform`` node: a macro
+    called on part of the template (intrinsic-function-reference-transform),
+    which API_CreateStack counts like a top-level ``Transform`` for
+    ``CAPABILITY_AUTO_EXPAND`` ("one or more macros")."""
+    stack = [value for section, value in template.items()
+             if section not in ("Parameters", "AWSTemplateFormatVersion", "Transform")]
+    while stack:
+        node = stack.pop()
+        if isinstance(node, dict):
+            if "Fn::Transform" in node:
+                return True
+            stack.extend(node.values())
+        elif isinstance(node, list):
+            stack.extend(node)
+    return False
+
+
+def _uses_macro(template):
+    """True when the template calls one or more macros: a top-level
+    ``Transform`` or an embedded ``Fn::Transform`` node. Both count for the
+    ``CAPABILITY_AUTO_EXPAND`` rule of API_CreateStack."""
+    return bool(template.get("Transform")) or _uses_embedded_macro(template)
+
+
+def _required_capabilities(template, strict=False):
+    """Return ``(capabilities, reason_types)`` for a parsed template:
+    ``CAPABILITY_NAMED_IAM`` when an IAM resource carries a custom name,
+    ``CAPABILITY_IAM`` for the other IAM resources, ``CAPABILITY_AUTO_EXPAND``
+    when the template declares a ``Transform``. ``reason_types`` are the IAM
+    types behind the IAM entry.
+
+    The default is ``GetTemplateSummary``'s rule (``_NAMED_IAM_PROPS``, every
+    ``AWS::IAM::*`` type, top-level ``Transform`` only); ``strict=True`` is
+    the documented rule the enforcement uses (``_CAPABILITY_IAM_TYPES``,
+    ``_CAPABILITY_NAMED_PROPS``, and an embedded ``Fn::Transform`` counts as a
+    macro too).
+    """
+    resources = template.get("Resources", {}) or {}
+    named_props = _CAPABILITY_NAMED_PROPS if strict else _NAMED_IAM_PROPS
+    named_iam_ids = []
+    unnamed_iam_ids = []
+    for logical_id, res in resources.items():
+        rtype = res.get("Type", "")
+        if strict:
+            if rtype not in _CAPABILITY_IAM_TYPES:
+                continue
+        elif not rtype.startswith("AWS::IAM::"):
+            continue
+        name_prop = named_props.get(rtype)
+        if name_prop and (res.get("Properties") or {}).get(name_prop):
+            named_iam_ids.append(logical_id)
+        else:
+            unnamed_iam_ids.append(logical_id)
+
+    capabilities = []
+    reason_types = []
+    if named_iam_ids:
+        capabilities.append("CAPABILITY_NAMED_IAM")
+        reason_types.extend(
+            sorted(set(resources[lid].get("Type", "") for lid in named_iam_ids))
+        )
+    elif unnamed_iam_ids:
+        capabilities.append("CAPABILITY_IAM")
+        reason_types.extend(
+            sorted(set(resources[lid].get("Type", "") for lid in unnamed_iam_ids))
+        )
+    macro = _uses_macro(template) if strict else bool(template.get("Transform"))
+    if macro:
+        capabilities.append("CAPABILITY_AUTO_EXPAND")
+    return capabilities, reason_types
+
+
+def _check_capabilities(sent, template, params, macros=True):
+    """Refuse a template whose required capabilities the request does not
+    acknowledge, the way CreateStack does: HTTP 400
+    ``InsufficientCapabilitiesException`` with ``Requires capabilities :
+    [CAPABILITY_IAM]`` and no stack created (measured on AWS for the IAM case).
+
+    ``sent`` is the template as the request sent it, ``template`` the same one
+    after the SAM transform. The macro rule reads ``sent``, because the
+    transform drops the ``Transform`` key it looks at; the IAM rule reads
+    ``template``, because a macro may add IAM resources and AWS asks for those
+    to be acknowledged as well (template-macros-overview.html).
+
+    Capabilities are IAM scope, so the check only runs under ``AUTH=true``;
+    without it every template is accepted as before. ``CAPABILITY_IAM`` is
+    satisfied by either IAM capability, ``CAPABILITY_NAMED_IAM`` only by
+    itself. Pass ``macros=False`` for ``CreateChangeSet``: the API reference
+    says ``CAPABILITY_AUTO_EXPAND`` "doesn't apply to creating change sets".
+    Returns an error response or ``None``."""
+    from ministack.app import AUTH
+    if not AUTH:
+        return None
+    given = set(_extract_string_members(params, "Capabilities"))
+    required = [cap for cap in _required_capabilities(template, strict=True)[0]
+                if cap != "CAPABILITY_AUTO_EXPAND"]
+    if macros and _uses_macro(sent):
+        required.append("CAPABILITY_AUTO_EXPAND")
+    missing = []
+    for cap in required:
+        if cap == "CAPABILITY_IAM" and "CAPABILITY_NAMED_IAM" in given:
+            continue
+        if cap not in given:
+            missing.append(cap)
+    if not missing:
+        return None
+    return _error("InsufficientCapabilitiesException",
+                  "Requires capabilities : [" + ", ".join(missing) + "]")
+
+
 # --- CreateStack ---
 
 def _create_stack(params):
@@ -76,7 +221,7 @@ def _create_stack(params):
                       f"Stack [{stack_name}] already exists")
 
     try:
-        template = _parse_template(template_body)
+        template = sent = _parse_template(template_body)
         template = _apply_sam_transform_if_applicable(template)
     except Exception as e:
         return _error("ValidationError", f"Template format error: {e}")
@@ -88,6 +233,12 @@ def _create_stack(params):
     tags_error = _validate_stack_tags(tags)
     if tags_error:
         return tags_error
+
+    # The macro rule reads the template as sent (the SAM transform above drops
+    # the Transform key), the IAM rule the transformed one (a macro can add
+    # IAM resources, and AWS asks for those to be acknowledged too).
+    if caps_error := _check_capabilities(sent, template, params):
+        return caps_error
 
     # Resolve parameters
     try:
@@ -703,7 +854,7 @@ def _update_stack(params):
             return _error("ValidationError", "TemplateBody or TemplateURL is required")
 
     try:
-        template = _parse_template(template_body)
+        template = sent = _parse_template(template_body)
         template = _apply_sam_transform_if_applicable(template)
     except Exception as e:
         return _error("ValidationError", f"Template format error: {e}")
@@ -719,6 +870,12 @@ def _update_stack(params):
     tags_error = _validate_stack_tags(tags)
     if tags_error:
         return tags_error
+
+    # The macro rule reads the template as sent (the SAM transform above drops
+    # the Transform key), the IAM rule the transformed one (a macro can add
+    # IAM resources, and AWS asks for those to be acknowledged too).
+    if caps_error := _check_capabilities(sent, template, params):
+        return caps_error
 
     try:
         param_values = _resolve_parameters(
@@ -916,40 +1073,7 @@ def _get_template_summary(params):
             "</member>"
         )
 
-    _NAMED_IAM_PROPS = {
-        "AWS::IAM::Role": "RoleName",
-        "AWS::IAM::User": "UserName",
-        "AWS::IAM::Group": "GroupName",
-        "AWS::IAM::Policy": "PolicyName",
-        "AWS::IAM::ManagedPolicy": "ManagedPolicyName",
-        "AWS::IAM::InstanceProfile": "InstanceProfileName",
-    }
-    named_iam_ids = []
-    unnamed_iam_ids = []
-    for logical_id, res in resources.items():
-        rtype = res.get("Type", "")
-        if not rtype.startswith("AWS::IAM::"):
-            continue
-        name_prop = _NAMED_IAM_PROPS.get(rtype)
-        if name_prop and res.get("Properties", {}).get(name_prop):
-            named_iam_ids.append(logical_id)
-        else:
-            unnamed_iam_ids.append(logical_id)
-
-    capabilities = []
-    caps_reason_types = []
-    if named_iam_ids:
-        capabilities.append("CAPABILITY_NAMED_IAM")
-        caps_reason_types.extend(
-            sorted(set(resources[lid].get("Type", "") for lid in named_iam_ids))
-        )
-    elif unnamed_iam_ids:
-        capabilities.append("CAPABILITY_IAM")
-        caps_reason_types.extend(
-            sorted(set(resources[lid].get("Type", "") for lid in unnamed_iam_ids))
-        )
-    if template.get("Transform"):
-        capabilities.append("CAPABILITY_AUTO_EXPAND")
+    capabilities, caps_reason_types = _required_capabilities(template)
 
     caps_xml = "".join(f"<member>{c}</member>" for c in capabilities)
     # AWS'es behavior here is very inconsistent with their docs. AWS doesn't necessarily return

--- a/tests/test_cfn.py
+++ b/tests/test_cfn.py
@@ -2499,6 +2499,473 @@ def test_cfn_get_template_summary(cfn):
     result = cfn.get_template_summary(TemplateBody=json.dumps(transform_tpl))
     assert "CAPABILITY_AUTO_EXPAND" in result["Capabilities"]
 
+
+# --- Capabilities are enforced under AUTH=true (in-process, no server) ---
+#
+# API_CreateStack / API_UpdateStack / API_CreateChangeSet, "Capabilities":
+# IAM resources need CAPABILITY_IAM or CAPABILITY_NAMED_IAM, custom-named
+# ones CAPABILITY_NAMED_IAM, a template with macros CAPABILITY_AUTO_EXPAND on
+# CreateStack / UpdateStack ("doesn't apply to creating change sets");
+# otherwise the InsufficientCapabilities error, HTTP 400. Measured on AWS for
+# an unnamed role: "Requires capabilities : [CAPABILITY_IAM]", no stack.
+
+_CAPS_ROLE_TEMPLATE = {
+    "AWSTemplateFormatVersion": "2010-09-09",
+    "Resources": {
+        "Role": {
+            "Type": "AWS::IAM::Role",
+            "Properties": {
+                "AssumeRolePolicyDocument": {"Version": "2012-10-17", "Statement": []},
+            },
+        }
+    },
+}
+_CAPS_NAMED_ROLE_TEMPLATE = {
+    "AWSTemplateFormatVersion": "2010-09-09",
+    "Resources": {
+        "Role": {
+            "Type": "AWS::IAM::Role",
+            "Properties": {
+                "RoleName": "cfn-caps-named-role",
+                "AssumeRolePolicyDocument": {"Version": "2012-10-17", "Statement": []},
+            },
+        }
+    },
+}
+# A SAM template the transform accepts. The transform generates an unnamed
+# execution role for the function, so a handler needs CAPABILITY_IAM for the
+# transformed template and CAPABILITY_AUTO_EXPAND for the macro. The helper
+# tests below pass this template untransformed, where only the macro counts.
+_CAPS_TRANSFORM_TEMPLATE = {
+    "AWSTemplateFormatVersion": "2010-09-09",
+    "Transform": "AWS::Serverless-2016-10-31",
+    "Resources": {
+        "Fn": {
+            "Type": "AWS::Serverless::Function",
+            "Properties": {
+                "Handler": "index.handler",
+                "Runtime": "python3.12",
+                "InlineCode": "def handler(event, context): return None",
+            },
+        },
+    },
+}
+_CAPS_BUCKET_TEMPLATE = {
+    "AWSTemplateFormatVersion": "2010-09-09",
+    "Resources": {"Bucket": {"Type": "AWS::S3::Bucket"}},
+}
+# PolicyName is a required property of AWS::IAM::Policy, not a custom name
+# (aws-resource-iam-policy.html): CAPABILITY_IAM is enough.
+_CAPS_POLICY_TEMPLATE = {
+    "AWSTemplateFormatVersion": "2010-09-09",
+    "Resources": {
+        "Policy": {
+            "Type": "AWS::IAM::Policy",
+            "Properties": {
+                "PolicyName": "cfn-caps-inline",
+                "PolicyDocument": {"Version": "2012-10-17", "Statement": []},
+                "Roles": ["cfn-caps-some-role"],
+            },
+        }
+    },
+}
+# Not one of the eight documented types: no capability needed.
+_CAPS_SERVICE_LINKED_ROLE_TEMPLATE = {
+    "AWSTemplateFormatVersion": "2010-09-09",
+    "Resources": {
+        "Slr": {
+            "Type": "AWS::IAM::ServiceLinkedRole",
+            "Properties": {"AWSServiceName": "autoscaling.amazonaws.com"},
+        }
+    },
+}
+_CAPS_NULL_PROPS_ROLE_TEMPLATE = {
+    "AWSTemplateFormatVersion": "2010-09-09",
+    "Resources": {"Role": {"Type": "AWS::IAM::Role", "Properties": None}},
+}
+
+
+def _caps_params(template, *capabilities, **extra):
+    """A parsed query-protocol request the way ``handle_request`` builds it."""
+    params = {"TemplateBody": [json.dumps(template)]}
+    for i, cap in enumerate(capabilities, 1):
+        params[f"Capabilities.member.{i}"] = [cap]
+    for key, value in extra.items():
+        params[key] = [value]
+    return params
+
+
+def _caps_error(response):
+    """``(status, code, message)`` of an in-process CloudFormation response."""
+    status, _headers, body = response
+    text = body.decode("utf-8")
+    code = re.search(r"<Code>([^<]*)</Code>", text)
+    message = re.search(r"<Message>([^<]*)</Message>", text)
+    return status, code.group(1) if code else "", message.group(1) if message else ""
+
+
+def test_cfn_required_capabilities_helper():
+    from ministack.services.cloudformation.handlers import _required_capabilities
+
+    assert _required_capabilities(_CAPS_BUCKET_TEMPLATE) == ([], [])
+    assert _required_capabilities(_CAPS_ROLE_TEMPLATE) == (
+        ["CAPABILITY_IAM"], ["AWS::IAM::Role"])
+    assert _required_capabilities(_CAPS_NAMED_ROLE_TEMPLATE) == (
+        ["CAPABILITY_NAMED_IAM"], ["AWS::IAM::Role"])
+    assert _required_capabilities(_CAPS_TRANSFORM_TEMPLATE) == (
+        ["CAPABILITY_AUTO_EXPAND"], [])
+    both = dict(_CAPS_NAMED_ROLE_TEMPLATE, Transform="AWS::LanguageExtensions")
+    assert _required_capabilities(both) == (
+        ["CAPABILITY_NAMED_IAM", "CAPABILITY_AUTO_EXPAND"], ["AWS::IAM::Role"])
+    assert _required_capabilities(_CAPS_NULL_PROPS_ROLE_TEMPLATE) == (
+        ["CAPABILITY_IAM"], ["AWS::IAM::Role"])
+
+    # The summary's rule stays as it was: PolicyName counts as a name and every
+    # AWS::IAM::* type needs a capability. The documented rule the enforcement
+    # uses (strict=True) differs on both.
+    assert _required_capabilities(_CAPS_POLICY_TEMPLATE) == (
+        ["CAPABILITY_NAMED_IAM"], ["AWS::IAM::Policy"])
+    assert _required_capabilities(_CAPS_POLICY_TEMPLATE, strict=True) == (
+        ["CAPABILITY_IAM"], ["AWS::IAM::Policy"])
+    assert _required_capabilities(_CAPS_SERVICE_LINKED_ROLE_TEMPLATE) == (
+        ["CAPABILITY_IAM"], ["AWS::IAM::ServiceLinkedRole"])
+    assert _required_capabilities(_CAPS_SERVICE_LINKED_ROLE_TEMPLATE, strict=True) == ([], [])
+    assert _required_capabilities(_CAPS_NAMED_ROLE_TEMPLATE, strict=True) == (
+        ["CAPABILITY_NAMED_IAM"], ["AWS::IAM::Role"])
+
+
+def test_cfn_capabilities_not_enforced_without_auth(monkeypatch):
+    import ministack.app as app_mod
+    from ministack.services.cloudformation import _change_sets, _stack_events, _stacks
+    from ministack.services.cloudformation.changesets import _create_change_set
+    from ministack.services.cloudformation.handlers import _check_capabilities
+
+    monkeypatch.setattr(app_mod, "AUTH", False)
+    # The check takes the template as sent and the transformed one; these
+    # templates are passed untransformed, so both arguments are the same.
+    assert _check_capabilities(
+        _CAPS_ROLE_TEMPLATE, _CAPS_ROLE_TEMPLATE, _caps_params(_CAPS_ROLE_TEMPLATE)) is None
+    assert _check_capabilities(
+        _CAPS_NAMED_ROLE_TEMPLATE, _CAPS_NAMED_ROLE_TEMPLATE,
+        _caps_params(_CAPS_NAMED_ROLE_TEMPLATE)) is None
+    assert _check_capabilities(
+        _CAPS_TRANSFORM_TEMPLATE, _CAPS_TRANSFORM_TEMPLATE,
+        _caps_params(_CAPS_TRANSFORM_TEMPLATE)) is None
+
+    # A handler accepts the IAM template without any capability, as before.
+    stack_name = "cfn-caps-noauth-cs"
+    try:
+        response = _create_change_set(_caps_params(
+            _CAPS_ROLE_TEMPLATE, StackName=stack_name,
+            ChangeSetName="cs1", ChangeSetType="CREATE"))
+        status, code, _ = _caps_error(response)
+        assert status == 200, code
+        assert stack_name in _stacks
+    finally:
+        stack = _stacks.pop(stack_name, None)
+        if stack:
+            _stack_events.pop(stack["StackId"], None)
+        for cs_id in [k for k, v in _change_sets.items()
+                      if v.get("StackName") == stack_name]:
+            _change_sets.pop(cs_id, None)
+
+
+def test_cfn_capabilities_check_under_auth(monkeypatch):
+    import ministack.app as app_mod
+    from ministack.services.cloudformation.handlers import _check_capabilities
+
+    monkeypatch.setattr(app_mod, "AUTH", True)
+
+    def check(template, *caps, **kw):
+        # Untransformed: the template as sent and the transformed one are equal.
+        response = _check_capabilities(
+            template, template, _caps_params(template, *caps), **kw)
+        return None if response is None else _caps_error(response)
+
+    refused = (400, "InsufficientCapabilitiesException",
+               "Requires capabilities : [CAPABILITY_IAM]")
+    assert check(_CAPS_BUCKET_TEMPLATE) is None
+    assert check(_CAPS_ROLE_TEMPLATE) == refused
+    assert check(_CAPS_ROLE_TEMPLATE, "CAPABILITY_AUTO_EXPAND") == refused
+    # "If you have IAM resources, you can specify either capability."
+    assert check(_CAPS_ROLE_TEMPLATE, "CAPABILITY_IAM") is None
+    assert check(_CAPS_ROLE_TEMPLATE, "CAPABILITY_NAMED_IAM") is None
+    # "If you have IAM resources with custom names, you must specify
+    # CAPABILITY_NAMED_IAM."
+    assert check(_CAPS_NAMED_ROLE_TEMPLATE, "CAPABILITY_IAM") == (
+        400, "InsufficientCapabilitiesException",
+        "Requires capabilities : [CAPABILITY_NAMED_IAM]")
+    assert check(_CAPS_NAMED_ROLE_TEMPLATE, "CAPABILITY_NAMED_IAM") is None
+    assert check(_CAPS_NAMED_ROLE_TEMPLATE, "CAPABILITY_IAM", "CAPABILITY_NAMED_IAM") is None
+    # A macro template needs CAPABILITY_AUTO_EXPAND on CreateStack / UpdateStack
+    # but not on CreateChangeSet.
+    assert check(_CAPS_TRANSFORM_TEMPLATE) == (
+        400, "InsufficientCapabilitiesException",
+        "Requires capabilities : [CAPABILITY_AUTO_EXPAND]")
+    assert check(_CAPS_TRANSFORM_TEMPLATE, "CAPABILITY_AUTO_EXPAND") is None
+    assert check(_CAPS_TRANSFORM_TEMPLATE, macros=False) is None
+    both = dict(_CAPS_ROLE_TEMPLATE, Transform="AWS::LanguageExtensions")
+    assert check(both, "CAPABILITY_IAM") == (
+        400, "InsufficientCapabilitiesException",
+        "Requires capabilities : [CAPABILITY_AUTO_EXPAND]")
+    assert check(both, "CAPABILITY_AUTO_EXPAND") == refused
+    assert check(both, "CAPABILITY_AUTO_EXPAND", "CAPABILITY_IAM") is None
+    # An AWS::IAM::Policy needs CAPABILITY_IAM only; a type outside the
+    # documented eight needs nothing; a null Properties is an unnamed resource.
+    assert check(_CAPS_POLICY_TEMPLATE) == refused
+    assert check(_CAPS_POLICY_TEMPLATE, "CAPABILITY_IAM") is None
+    assert check(_CAPS_SERVICE_LINKED_ROLE_TEMPLATE) is None
+    assert check(_CAPS_NULL_PROPS_ROLE_TEMPLATE) == refused
+
+
+def test_cfn_create_stack_refuses_missing_capabilities_under_auth(monkeypatch):
+    import ministack.app as app_mod
+    from ministack.services.cloudformation import _stack_events, _stacks
+    from ministack.services.cloudformation.handlers import _create_stack
+
+    monkeypatch.setattr(app_mod, "AUTH", True)
+    stack_name = "cfn-caps-auth-create"
+
+    try:
+        response = _create_stack(_caps_params(_CAPS_ROLE_TEMPLATE, StackName=stack_name))
+        assert _caps_error(response) == (
+            400, "InsufficientCapabilitiesException",
+            "Requires capabilities : [CAPABILITY_IAM]")
+        assert stack_name not in _stacks
+
+        response = _create_stack(_caps_params(
+            _CAPS_NAMED_ROLE_TEMPLATE, "CAPABILITY_IAM", StackName=stack_name))
+        assert _caps_error(response) == (
+            400, "InsufficientCapabilitiesException",
+            "Requires capabilities : [CAPABILITY_NAMED_IAM]")
+        assert stack_name not in _stacks
+
+        # Two capabilities missing at once. The macro rule reads the template
+        # as sent, whose Transform the SAM transform drops; the IAM rule reads
+        # the transformed template, which carries the generated function role.
+        pytest.importorskip("samtranslator")
+        response = _create_stack(_caps_params(_CAPS_TRANSFORM_TEMPLATE, StackName=stack_name))
+        assert _caps_error(response) == (
+            400, "InsufficientCapabilitiesException",
+            "Requires capabilities : [CAPABILITY_IAM, CAPABILITY_AUTO_EXPAND]")
+        assert stack_name not in _stacks
+
+        response = _create_stack(_caps_params(
+            _CAPS_TRANSFORM_TEMPLATE, "CAPABILITY_AUTO_EXPAND", StackName=stack_name))
+        assert _caps_error(response) == (
+            400, "InsufficientCapabilitiesException",
+            "Requires capabilities : [CAPABILITY_IAM]")
+        assert stack_name not in _stacks
+
+        response = _create_stack(_caps_params(
+            _CAPS_NULL_PROPS_ROLE_TEMPLATE, StackName=stack_name))
+        assert _caps_error(response) == (
+            400, "InsufficientCapabilitiesException",
+            "Requires capabilities : [CAPABILITY_IAM]")
+        assert stack_name not in _stacks
+    finally:
+        stack = _stacks.pop(stack_name, None)
+        if stack:
+            _stack_events.pop(stack["StackId"], None)
+
+
+def test_cfn_embedded_fn_transform_needs_auto_expand_under_auth(monkeypatch):
+    """A macro called on part of the template (``Fn::Transform``, e.g.
+    ``AWS::Include``) has no top-level ``Transform`` but is a macro all the
+    same, so CreateStack needs CAPABILITY_AUTO_EXPAND for it. The summary's
+    rule stays top-level only."""
+    import ministack.app as app_mod
+    from ministack.services.cloudformation import _stacks
+    from ministack.services.cloudformation.handlers import (
+        _check_capabilities,
+        _create_stack,
+        _required_capabilities,
+    )
+
+    embedded = {
+        "AWSTemplateFormatVersion": "2010-09-09",
+        "Resources": {
+            "Bucket": {
+                "Type": "AWS::S3::Bucket",
+                "Properties": {
+                    "Fn::Transform": {
+                        "Name": "AWS::Include",
+                        "Parameters": {"Location": "s3://example.local/bucket-props.yaml"},
+                    },
+                },
+            },
+        },
+    }
+    assert _required_capabilities(embedded) == ([], [])
+    assert _required_capabilities(embedded, strict=True) == (["CAPABILITY_AUTO_EXPAND"], [])
+    # A parameter default is not walked: a macro name there is not a macro call.
+    in_parameters = {
+        "AWSTemplateFormatVersion": "2010-09-09",
+        "Parameters": {"P": {"Type": "String", "Default": "Fn::Transform"}},
+        "Resources": {"Bucket": {"Type": "AWS::S3::Bucket"}},
+    }
+    assert _required_capabilities(in_parameters, strict=True) == ([], [])
+
+    monkeypatch.setattr(app_mod, "AUTH", True)
+    refused = (400, "InsufficientCapabilitiesException",
+               "Requires capabilities : [CAPABILITY_AUTO_EXPAND]")
+    assert _caps_error(
+        _check_capabilities(embedded, embedded, _caps_params(embedded))) == refused
+    assert _check_capabilities(
+        embedded, embedded, _caps_params(embedded, "CAPABILITY_AUTO_EXPAND")) is None
+    # Not on a change set (macros=False).
+    assert _check_capabilities(embedded, embedded, _caps_params(embedded), macros=False) is None
+
+    stack_name = "cfn-caps-auth-embedded"
+    response = _create_stack(_caps_params(embedded, StackName=stack_name))
+    assert _caps_error(response) == refused
+    assert stack_name not in _stacks
+
+
+def test_cfn_create_stack_capabilities_parsed_from_wire_under_auth(monkeypatch):
+    import asyncio
+    from urllib.parse import urlencode
+
+    import ministack.app as app_mod
+    from ministack.services.cloudformation import _stacks, handle_request
+
+    monkeypatch.setattr(app_mod, "AUTH", True)
+    stack_name = "cfn-caps-auth-wire"
+    body = urlencode({
+        "Action": "CreateStack",
+        "Version": "2010-05-15",
+        "StackName": stack_name,
+        "TemplateBody": json.dumps(_CAPS_NAMED_ROLE_TEMPLATE),
+        "Capabilities.member.1": "CAPABILITY_IAM",
+        "Capabilities.member.2": "CAPABILITY_AUTO_EXPAND",
+    }).encode()
+    headers = {"content-type": "application/x-www-form-urlencoded"}
+    response = asyncio.run(handle_request("POST", "/", headers, body, {}))
+    # CAPABILITY_IAM arrived and was considered: only NAMED_IAM is missing.
+    assert _caps_error(response) == (
+        400, "InsufficientCapabilitiesException",
+        "Requires capabilities : [CAPABILITY_NAMED_IAM]")
+    assert stack_name not in _stacks
+
+
+def test_cfn_update_stack_refuses_missing_capabilities_under_auth(monkeypatch):
+    import ministack.app as app_mod
+    from ministack.services.cloudformation import _stack_events, _stacks
+    from ministack.services.cloudformation.handlers import _update_stack
+
+    monkeypatch.setattr(app_mod, "AUTH", True)
+    stack_name = "cfn-caps-auth-update"
+    stack_id = f"arn:aws:cloudformation:us-east-1:000000000000:stack/{stack_name}/caps-1"
+    _stacks[stack_name] = {
+        "StackName": stack_name,
+        "StackId": stack_id,
+        "StackStatus": "CREATE_COMPLETE",
+        "Parameters": [],
+        "Tags": [],
+        "Outputs": [],
+        "_region": "us-east-1",
+        "_resources": {},
+        "_template": _CAPS_BUCKET_TEMPLATE,
+        "_template_body": json.dumps(_CAPS_BUCKET_TEMPLATE),
+        "_resolved_params": {},
+        "_conditions": {},
+    }
+    _stack_events[stack_id] = []
+    try:
+        response = _update_stack(_caps_params(_CAPS_ROLE_TEMPLATE, StackName=stack_name))
+        assert _caps_error(response) == (
+            400, "InsufficientCapabilitiesException",
+            "Requires capabilities : [CAPABILITY_IAM]")
+        assert _stacks[stack_name]["StackStatus"] == "CREATE_COMPLETE"
+
+        pytest.importorskip("samtranslator")
+        response = _update_stack(_caps_params(_CAPS_TRANSFORM_TEMPLATE, StackName=stack_name))
+        assert _caps_error(response) == (
+            400, "InsufficientCapabilitiesException",
+            "Requires capabilities : [CAPABILITY_IAM, CAPABILITY_AUTO_EXPAND]")
+        assert _stacks[stack_name]["StackStatus"] == "CREATE_COMPLETE"
+
+        # UsePreviousTemplate re-checks the stored template (unmeasured on AWS).
+        _stacks[stack_name]["_template"] = _CAPS_ROLE_TEMPLATE
+        _stacks[stack_name]["_template_body"] = json.dumps(_CAPS_ROLE_TEMPLATE)
+        response = _update_stack({
+            "StackName": [stack_name], "UsePreviousTemplate": ["true"],
+            "Parameters.member.1.ParameterKey": ["Unused"],
+        })
+        assert _caps_error(response) == (
+            400, "InsufficientCapabilitiesException",
+            "Requires capabilities : [CAPABILITY_IAM]")
+        assert _stacks[stack_name]["StackStatus"] == "CREATE_COMPLETE"
+    finally:
+        _stacks.pop(stack_name, None)
+        _stack_events.pop(stack_id, None)
+
+
+def test_cfn_create_change_set_refuses_missing_iam_capability_under_auth(monkeypatch):
+    import ministack.app as app_mod
+    from ministack.services.cloudformation import _change_sets, _stack_events, _stacks
+    from ministack.services.cloudformation.changesets import _create_change_set
+
+    monkeypatch.setattr(app_mod, "AUTH", True)
+    stack_name = "cfn-caps-auth-cs"
+
+    try:
+        response = _create_change_set(_caps_params(
+            _CAPS_ROLE_TEMPLATE, StackName=stack_name,
+            ChangeSetName="cs1", ChangeSetType="CREATE"))
+        assert _caps_error(response) == (
+            400, "InsufficientCapabilitiesException",
+            "Requires capabilities : [CAPABILITY_IAM]")
+        # A refused CREATE change set leaves no REVIEW_IN_PROGRESS stack behind.
+        assert stack_name not in _stacks
+
+        response = _create_change_set(_caps_params(
+            _CAPS_NAMED_ROLE_TEMPLATE, "CAPABILITY_IAM", StackName=stack_name,
+            ChangeSetName="cs1", ChangeSetType="CREATE"))
+        assert _caps_error(response) == (
+            400, "InsufficientCapabilitiesException",
+            "Requires capabilities : [CAPABILITY_NAMED_IAM]")
+        assert stack_name not in _stacks
+    finally:
+        stack = _stacks.pop(stack_name, None)
+        if stack:
+            _stack_events.pop(stack["StackId"], None)
+        for cs_id in [k for k, v in _change_sets.items()
+                      if v.get("StackName") == stack_name]:
+            _change_sets.pop(cs_id, None)
+
+    # With CAPABILITY_IAM the set is created and the REVIEW_IN_PROGRESS
+    # placeholder stays.
+    try:
+        response = _create_change_set(_caps_params(
+            _CAPS_ROLE_TEMPLATE, "CAPABILITY_IAM", StackName=stack_name,
+            ChangeSetName="cs1", ChangeSetType="CREATE"))
+        status, code, _ = _caps_error(response)
+        assert status == 200, code
+        assert _stacks[stack_name]["StackStatus"] == "REVIEW_IN_PROGRESS"
+    finally:
+        stack = _stacks.pop(stack_name, None)
+        if stack:
+            _stack_events.pop(stack["StackId"], None)
+        for cs_id in [k for k, v in _change_sets.items()
+                      if v.get("StackName") == stack_name]:
+            _change_sets.pop(cs_id, None)
+
+    # CAPABILITY_AUTO_EXPAND "doesn't apply to creating change sets": a macro
+    # template without it is not refused for capabilities.
+    macro = dict(_CAPS_BUCKET_TEMPLATE, Transform="AWS::LanguageExtensions")
+    try:
+        response = _create_change_set(_caps_params(
+            macro, StackName=stack_name, ChangeSetName="cs1", ChangeSetType="CREATE"))
+        assert _caps_error(response)[1] != "InsufficientCapabilitiesException"
+    finally:
+        stack = _stacks.pop(stack_name, None)
+        if stack:
+            _stack_events.pop(stack["StackId"], None)
+        for cs_id in [k for k, v in _change_sets.items()
+                      if v.get("StackName") == stack_name]:
+            _change_sets.pop(cs_id, None)
+
 def test_cfn_list_stacks(cfn):
     for name in ("cfn-t12-a", "cfn-t12-b"):
         template = {


### PR DESCRIPTION
Part of #1601 (B6). Capabilities are IAM scope, so the check is permissive by default and enforced under `AUTH=true`.

`CreateStack`, `UpdateStack` and `CreateChangeSet` accepted a template with IAM resources or a `Transform` no matter what the request's `Capabilities` said. Real CloudFormation refuses such a request before it touches anything: `InsufficientCapabilitiesException`, HTTP 400, `Requires capabilities : [CAPABILITY_IAM]`, and no stack is created (measured on a real account for an unnamed `AWS::IAM::Role`, see the issue). A deploy that fails on AWS for a missing `--capabilities` went through here.

The rules, from the `Capabilities` parameter of the three API pages:

- An IAM resource of the eight listed types (`AWS::IAM::AccessKey`, `Group`, `InstanceProfile`, `ManagedPolicy`, `Policy`, `Role`, `User`, `UserToGroupAddition`) needs `CAPABILITY_IAM` or `CAPABILITY_NAMED_IAM`; "you can specify either capability".
- An IAM resource with a custom name needs `CAPABILITY_NAMED_IAM`: "If you have IAM resources with custom names, you must specify CAPABILITY_NAMED_IAM". The name properties are `RoleName`, `UserName`, `GroupName`, `ManagedPolicyName` and `InstanceProfileName`. `PolicyName` of an `AWS::IAM::Policy` is a required property (aws-resource-iam-policy.html), not a custom name, so an inline policy needs `CAPABILITY_IAM` only.
- A template with macros ("one or more macros", including `AWS::Include` and `AWS::Serverless`) needs `CAPABILITY_AUTO_EXPAND` on `CreateStack` and `UpdateStack`. That is a top-level `Transform` or an `Fn::Transform` node inside the template, which calls a macro on part of it (intrinsic-function-reference-transform.html). On `CreateChangeSet` it does not: "This capacity doesn't apply to creating change sets, and specifying it when creating change sets has no effect."
- The IAM rule applies to the processed template, so the resources a macro adds count too: "A macro can add IAM resources to your template. For these resources, CloudFormation requires you to acknowledge their capabilities" (template-macros-overview.html). A SAM function without an explicit role is the common case. The transform generates an unnamed `AWS::IAM::Role` for it, so the request needs `CAPABILITY_IAM` on top of `CAPABILITY_AUTO_EXPAND`.

What changes:

- `handlers.py`: the capability computation of `GetTemplateSummary` (named vs unnamed IAM resources, `Transform`) moves into one module-level helper, `_required_capabilities(template, strict=False)`. The summary calls it with the default and reports the same set as before. The enforcement calls it with `strict=True`, which uses the two documented sets above (`_CAPABILITY_IAM_TYPES`, and `_CAPABILITY_NAMED_PROPS`, the summary's name map without `AWS::IAM::Policy`) and also walks every section except `Parameters`, `AWSTemplateFormatVersion` and `Transform` for an `Fn::Transform` node; the summary keeps looking at the top-level `Transform` only. A new `_check_capabilities(sent, template, params, macros=True)` compares the required set with the request's `Capabilities.member.N` (or the JSON-protocol list) and returns the `InsufficientCapabilitiesException` response with the missing capabilities. The check only runs when `AUTH` is on. With `AUTH` off every handler behaves as before. A resource with `Properties: null` is treated as unnamed; the summary used to raise on it.
- The check reads two templates. `sent` is the template as the request sent it and carries the macro rule, because the SAM transform drops the `Transform` key. `template` is the same one after the transform and carries the IAM rule, so the resources a macro generates are counted too.
- `CreateStack` and `UpdateStack` keep a reference to the template as sent and run the check after the transform and after the tag validation. `UpdateStack` with `UsePreviousTemplate` checks the stored template the same way.
- `changesets.py`: `CreateChangeSet` calls the check with `macros=False`, at the same point, so the three handlers agree on the order. The IAM rule runs there as well, since the same page says "you might need to acknowledge IAM capabilities when you create the change set, depending on whether the referenced macros contain IAM resources". A refused `CREATE` change set drops the `REVIEW_IN_PROGRESS` placeholder, as a rejected template already did, so no stack is left behind.
- `CHANGELOG.md`: one bullet under Fixed.

Tests, `tests/test_cfn.py`: eight in-process tests next to the `GetTemplateSummary` test. Three of them exercise the helpers directly. Those three cover both rules, the summary's and the strict one, including `AWS::IAM::Policy`, `AWS::IAM::ServiceLinkedRole` and a role with `Properties: null`, and the check with `AUTH` off, where nothing is refused and a change set for an IAM template is created. With `AUTH` on the check refuses an unnamed role without a capability and accepts it with either one, refuses a named role given `CAPABILITY_IAM` alone, accepts an inline policy with `CAPABILITY_IAM`, asks for nothing for a service-linked role, refuses a `Transform` template without `CAPABILITY_AUTO_EXPAND` and does not refuse it on `CreateChangeSet`, and refuses a template whose only macro is an embedded `Fn::Transform`. The other five drive the handlers. Each of the three refuses and leaves no stack, the updated stack stays `CREATE_COMPLETE`, a SAM function template is refused for both capabilities at once and then for the generated role alone once `CAPABILITY_AUTO_EXPAND` is given, a `CREATE` change set with `CAPABILITY_IAM` is created with its placeholder, and one request goes through `handle_request` with a query-protocol body to show that `Capabilities.member.N` is parsed. No existing test changed.

`tests/test_cfn.py` against a server run from the branch (`AUTH` unset): 401 passed. The eight new tests in-process: 8 passed.

A server started with `AUTH=true` (boto3 against it): an unnamed role without capabilities is refused with `Requires capabilities : [CAPABILITY_IAM]` (HTTP 400) and accepted with `CAPABILITY_IAM`; a named role with `CAPABILITY_IAM` only is refused with `Requires capabilities : [CAPABILITY_NAMED_IAM]` and accepted with it; `UpdateStack` of the accepted stack without capabilities is refused; the refused requests leave no stack.

Not covered: whether AWS requires `CAPABILITY_AUTO_EXPAND` for an embedded `Fn::Transform` alone, without a top-level `Transform`, is not measured; the API page's "one or more macros" is read that way. The message text for a missing `CAPABILITY_NAMED_IAM` or `CAPABILITY_AUTO_EXPAND` follows the measured `Requires capabilities : [...]` pattern, but was not measured itself. The order in which two missing capabilities are listed is not measured either. The code puts the IAM one first. The order between a tag error and a capability error, and the check on `UpdateStack` with `UsePreviousTemplate`, are not measured either. `GetTemplateSummary` keeps its earlier rule: it reports `CAPABILITY_NAMED_IAM` for an `AWS::IAM::Policy` and `CAPABILITY_IAM` for every `AWS::IAM::*` type, as before; the enforcement is limited to the eight documented types and the five name properties. A `GetTemplateSummary` call on a real account with a role and an inline policy would settle the summary rule. Whether AWS refuses a `CreateChangeSet` for IAM resources that a macro generates is not measured. AWS cannot know them before it processes the template, and the macro page only says you might need to acknowledge the capability at that point, so a `CreateChangeSet` here may be stricter than AWS. `DescribeStacks` and `DescribeChangeSet` still do not report a `Capabilities` field, which is unchanged by this PR. Nested stacks are only under-enforced: the parent's capabilities are checked, the child template of an `AWS::CloudFormation::Stack` is deployed without a check (AWS asks the parent to acknowledge the capabilities of nested stacks, using-cfn-nested-stacks.html). An unknown value in `Capabilities` is not refused, and the "only one of `Capabilities` and `ResourceType`" rule is not enforced.

References: https://docs.aws.amazon.com/AWSCloudFormation/latest/APIReference/API_CreateStack.html, https://docs.aws.amazon.com/AWSCloudFormation/latest/APIReference/API_UpdateStack.html, https://docs.aws.amazon.com/AWSCloudFormation/latest/APIReference/API_CreateChangeSet.html, https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/control-access-with-iam.html#using-iam-capabilities, https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-resource-iam-policy.html, https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/template-macros-overview.html, https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-nested-stacks.html, https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/intrinsic-function-reference-transform.html
